### PR TITLE
[Feat] allow unsecure cookies

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -29,6 +29,7 @@ function Strategy(options, verify) {
   this._passReqToCallback = options.passReqToCallback || false;
   this._jwtHeaderKey = options.jwtHeaderKey || 'authorization';
   this._jwtCookieName = options.jwtCookieName || 'jwt';
+  this._jwtCookieSecure = options.jwtCookieSecure !== false;
   this._secretOrPublicKey = options.secretOrPublicKey;
 
   this._jwtHeaderKey = this._jwtHeaderKey.toLowerCase();
@@ -48,10 +49,15 @@ Strategy.prototype.authenticate = function(req, options) {
 
   var jwtString = null;
 
-  if (req.signedCookies && this._jwtCookieName in req.signedCookies)
+  if (this._jwtCookieSecure && req.signedCookies &&
+    this._jwtCookieName in req.signedCookies) {
     jwtString = req.signedCookies[this._jwtCookieName];
-  else if (req.headers && this._jwtHeaderKey in req.headers)
+  } else if (!this._jwtCookieSecure && req.cookies &&
+    this._jwtCookieName in req.cookies) {
+    jwtString = req.cookies[this._jwtCookieName];
+  } else if (req.headers && this._jwtHeaderKey in req.headers) {
     jwtString = req.get(this._jwtHeaderKey);
+  }
 
   if (!jwtString) return this.fail({
     message: options.badRequestMessage || 'Missing token'

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "chai-passport-strategy": "^1.0.0"
+    "chai-passport-strategy": "^1.0.0",
+    "mocha": "^3.2.0"
   }
 }


### PR DESCRIPTION
 - Add mocka in devDependecies for running tests out of the box
 - Add `jwtCookieSecure` options to use unsecure cookies (disabled by default)

Exemple : 
```javascript
  passport.use('jwt-cookie', new JwtCookieCombo({
    secretOrPublicKey: process.env.JWT_SECRET,
    jwtCookieName: 'jwt',
    jwtCookieSecure: false,
    jwtVerifyOptions: {
      ignoreExpiration: true,
    },
  }, (payload, done) => {});
```
